### PR TITLE
Minor bugfix for linkify

### DIFF
--- a/src/statuses/views/common.clj
+++ b/src/statuses/views/common.clj
@@ -49,6 +49,6 @@
         anchor  (fn [[m _]] (str "<a href='" m "'>" m "</a>"))]
     (-> text
         escape-html
-        (clojure.string/replace #"@(\w*)" handle)
+        (clojure.string/replace #"@(\w+)" handle)
         (clojure.string/replace uri anchor)
-        (clojure.string/replace #"#(\w*)" hashtag))))
+        (clojure.string/replace #"#(\w+)" hashtag))))


### PR DESCRIPTION
I'm not quite sure but I think there is a minor bug in statuses.views.common/linkifiy:

(linkify "foo @ bar")
"foo @< a href='/statuses/updates?author=' >< /a > bar"

After change:

(linkify "foo @ bar")
"foo @ bar"

The 'normal' case still works.

(linkify "foo @bar")
"foo @< a href='/statuses/updates?author=bar' >bar< /a >"

This applies to hashtags as well.
