### PR TITLE
css fix padding-bottom of li-elements

### DIFF
--- a/public/statuses/css/statuses.css
+++ b/public/statuses/css/statuses.css
@@ -12,7 +12,7 @@ ul {
     margin: 0;
 }
 
-li {
+li.post {
     padding-bottom: 10px;
 }
 


### PR DESCRIPTION
I reassigned the padding-bottom of li-elements only to li.post
At the moment the Bootstrap layout was a little bit destructed.
