### PR TITLE
Hostname on which jetty listens is now configurable

### DIFF
--- a/config.clj
+++ b/config.clj
@@ -2,6 +2,7 @@
  :database-path "data/db.json"
  :save-interval 2
  :http-port     8080
+ :host          "localhost"
  :run-mode      :dev
  ; {username} is replaced with the username
  ;:avatar-url   "https://.../users/{username}/avatar/32x32"}

--- a/src/statuses/server.clj
+++ b/src/statuses/server.clj
@@ -22,4 +22,4 @@
   (println "Starting server on port"  "in mode" (config :run-mode))
   (run-jetty
    (if (= (config :run-mode) :dev) (wrap-reload app) app)
-   {:port (config :http-port) :join? false}))
+   {:port (config :http-port) :join? false :host (config :host)}))


### PR DESCRIPTION
config.clj now contains a new entry:

:host "localhost"

This is passed to jetty in statuses.server/-main.

Default behaviour: Only accept connections from localhost. If the server should be accessible from outside, set the :host property to "0.0.0.0".
