### PR TITLE
Updated statuses.css as discussed in #51

### DIFF
--- a/public/statuses/css/statuses.css
+++ b/public/statuses/css/statuses.css
@@ -24,6 +24,12 @@ li.post {
     margin-right: 0.5em;
     max-width: 32px;
     max-height: 32px;
+    overflow: hidden;
+}
+
+.content, 
+.meta { 
+    margin-left: 40px;
 }
 
 .content {


### PR DESCRIPTION
In #51 we discussed to add a left margin to .content and .meta to preserve a consistent indention. In case avatar images can't be loaded `overflow: hidden;` will prevent alternative texts from interfering with status messages.
