### PR TITLE
Fix offset on next link.

### DIFF
--- a/src/statuses/routing.clj
+++ b/src/statuses/routing.clj
@@ -50,7 +50,7 @@
         (assoc-in ~@body [:headers "etag"] etag-str#))))
 
 (defn updates-page [params request]
-  (let [next (next-uri (update-in params [:offset] #(+ 25 %)) request)
+  (let [next (next-uri (update-in params [:offset] (partial + (:limit params))) request)
         {:keys [limit offset author query format]} params]
     (with-etag request (:time (first (core/get-latest @db 1 offset author query)))
       (let [items (->> (core/get-latest @db limit offset author query)


### PR DESCRIPTION
Fixes #120.

The next link now increases the offset by the amount of limit instead of
hardcoded 25.
