### PR TITLE
Upgrade eastwood plugin to 0.2.0.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,9 +11,10 @@
                  [clj-time "0.8.0"]
                  [org.clojure/data.json "0.2.5"]]
   :pedantic? :abort
-  :plugins [[jonase/eastwood "0.1.5"]]
+  :plugins [[jonase/eastwood "0.2.0"]]
   :profiles {:dev {:dependencies [[ring-mock "0.1.5"]]}
              :uberjar {:aot [statuses.server]}}
   :main statuses.server
-  :aliases {"lint" "eastwood"})
+  :aliases {"lint" "eastwood"}
+  :eastwood {:exclude-linters [:constant-test]})
 


### PR DESCRIPTION
Exclude of linter _constant-test_ is necessary because it evaluates the
expanded _html5_ macro defined by _hiccup_ which produces a warning.
