### PR TITLE
Change JSON time format to 014-11-27T14:23:28.044Z.

### DIFF
--- a/src/statuses/backend/time.clj
+++ b/src/statuses/backend/time.clj
@@ -9,6 +9,3 @@
   (str (local/format-local-time time :date) " "
        (local/format-local-time time :hour-minute-second)))
 
-(defn utc-to-time [s]
-  (.toDateTime (format/parse-local (format/formatters :rfc822) s)))
-


### PR DESCRIPTION
Fixes #136.

**Note**: For the backend this is backwards compatible as we read the
old format as well but for the JSON API this breaks the format.
