### PR TITLE
Update compojure to 1.3.1.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
             :comments "A business-friendly OSS license"}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [ring "1.3.2"]
-                 [compojure "1.2.2"]
+                 [compojure "1.3.1"]
                  [clj-time "0.8.0"]
                  [org.clojure/data.json "0.2.5"]]
   :pedantic? :abort


### PR DESCRIPTION
Sorry. The update to 1.2.2 was a branch from last week. Compojure was updated to 1.3.1 in the meantime.
