### PR TITLE
escape the "&" in the uri which is used as feed id

### DIFF
--- a/src/statuses/views/atom.clj
+++ b/src/statuses/views/atom.clj
@@ -46,7 +46,7 @@
   [items base-uri feed-uri]
   (into [:feed {:xmlns "http://www.w3.org/2005/Atom"}
          [:title "innoQ Status updates"]
-         [:id feed-uri]
+         [:id (escape-html feed-uri)]
          [:updated (as-rfc3339 (:time (first items)))]
          [:link {:rel "self"
                  :type "application/atom+xml"


### PR DESCRIPTION
The atom feed is now valid, after escaping the ampersand inside the feed id.
This fixes #167 "Atom feed for mentions isn't valid".

Validation tested with thunderbirds feedreader.