### PR TITLE
adding port, host and conf (for configuration file) as CLI Parameter

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,8 @@
                  [ring "1.3.2"]
                  [compojure "1.3.3"]
                  [clj-time "0.9.0"]
-                 [org.clojure/data.json "0.2.6"]]
+                 [org.clojure/data.json "0.2.6"]
+                 [org.clojure/tools.cli "0.3.1"]]
   :pedantic? :abort
   :plugins [[jonase/eastwood "0.2.0"]]
   :profiles {:dev {:dependencies [[ring-mock "0.1.5"]]}

--- a/src/statuses/server.clj
+++ b/src/statuses/server.clj
@@ -5,6 +5,7 @@
             [ring.middleware.params :refer [wrap-params]]
             [ring.middleware.reload :refer [wrap-reload]]
             [ring.middleware.resource :refer [wrap-resource]]
+            [clojure.tools.cli :refer [parse-opts]]
             [ring.middleware.stacktrace :refer [wrap-stacktrace]]
             [statuses.backend.persistence :as persistence]
             [statuses.configuration :as cfg :refer [config]]
@@ -19,18 +20,29 @@
       wrap-not-modified
       wrap-stacktrace))
 
-(defn -main [& m]
-  (cfg/init! (or (first m) "config.clj"))
-  (println "Configuration: " (config))
-  (persistence/init! (config :database-path) (config :save-interval))
-  (println "Starting server on host"  (config :host)
-           "port" (config :http-port)
-           "in mode" (config :run-mode))
-  (run-jetty
-    (if (= (config :run-mode) :dev)
-      (wrap-reload app)
-      app)
-    {:host (config :host)
-     :port (config :http-port)
-     :join? false}))
+
+(def cli-options
+  [["-p" "--port PORT" "Port number" :parse-fn #(Integer/parseInt %)]
+  ["-h" "--host HOST" "Hostname"]
+  ["-c" "--conf ConfigurationFile" "The Location of the Configuration File"]])
+
+(defn -main [& args]
+  (let [{:keys [options arguments errors summary]} (parse-opts args cli-options)]
+    (cfg/init! (or (:conf options) "config.clj"))
+    (println "Configuration: " (config))
+    (println "CLI Options: " (str options))
+    (persistence/init! (config :database-path) (config :save-interval))
+    
+    (println "Starting server on host" (or (:host options) (config :host))
+             "port" (or (:port options) (config :http-port))
+             "in mode" (config :run-mode))
+    (run-jetty
+      (if (= (config :run-mode) :dev)
+        (wrap-reload app)
+        app)
+      {:host (or (:host options) (config :host))
+       :port (or (:port options) (config :http-port))
+       :join? false}))
+  )
+
 


### PR DESCRIPTION
You can now inject Port, Hostname and Configuration File Location into the Application during Runtime:

````
lein run  --port 1234 --hostname example.com
lein run  --conf /usr/secure/config.clj 
java -jar target/statuses-1.0.0-SNAPSHOT-standalone.jar --port 1234
