### PR TITLE
Change name of generated uberjar to statuses.jar

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,5 +17,6 @@
              :uberjar {:aot [statuses.server]}}
   :main statuses.server
   :aliases {"lint" "eastwood"}
+  :uberjar-name "statuses.jar"
   :eastwood {:exclude-linters [:constant-test]})
 


### PR DESCRIPTION
Makes deployment easier and there is not much information in keeping the
version number and the standalone part.